### PR TITLE
Add credential provider to factory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   - php: 7.4snapshot
   - php: nightly
 
-install: composer install --no-interaction --classmap-authoritative --no-suggest --ignore-platform-reqs
+install: composer update --no-interaction --classmap-authoritative --no-suggest --ignore-platform-reqs --prefer-lowest
 
 script: vendor/bin/phpunit --configuration phpunit.xml
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ $response = $awsSignedHandler([
 ]);
 ```
 
+## AWS Credentials Provider
+
+By default the library will use the default credentials provider provided by AWS. Lets say you want to provide static credentials from environment variables instead:
+
+```php
+use Nekman\AwsRingHttpSigner\AwsRingHttpSignerFactory;
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
+
+$credentials = new Credentials(getenv("AWS_KEY"), getenv("AWS_SECRET"));
+$credentialProvider = CredentialProvider::fromCredentials($credentials);
+
+$awsRingHttpSigner = AwsRingHttpSignerFactory::create($awsRegion, $credentialProvider);
+```
+
+There are many other ways to load credentials. You can [read more about loading credentials in the AWS documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html).
+
 ### Usage with Elasticsearch
 
 Install Elasticsearch separetely:
@@ -60,7 +77,3 @@ $client = ClientBuilder::create()
 ```
 
 All requests using Elasticsearch will now be signed with AWS credentials.
-
-## AWS Credentials Provider
-
-By default this library will use the `\Aws\Credentials\CredentialProvider::defaultProvider()` to sign requests. If you want to use something else, you must skip instantiating the middleware using the factory and instantiate it yourself, calling `new AwsRingHttpSigner($signature, $credentialsProvider);`. You can read more about [loading credentials in the AWS documentation](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_provider.html).

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "prefer-lowest": true,
     "keywords": [
         "ring",
         "http",
@@ -30,7 +29,7 @@
         "aws/aws-sdk-php": "^3.0",
         "psr/http-message": "^1.0",
         "guzzlehttp/ringphp": "^1.0",
-        "guzzlehttp/psr7": "^1.6"
+        "guzzlehttp/psr7": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",

--- a/src/AwsRingHttpSigner.php
+++ b/src/AwsRingHttpSigner.php
@@ -104,7 +104,7 @@ class AwsRingHttpSigner implements AwsRingHttpSignerInterface
             // There's a bug in parse_url where an address without
             // scheme is parsed as "path" and not "host"
             if (empty($host)) {
-                $host = $request->getUri()->getPath();
+                $host = $path;
                 $path = null;
             }
             

--- a/src/AwsRingHttpSignerFactory.php
+++ b/src/AwsRingHttpSignerFactory.php
@@ -44,9 +44,12 @@ class AwsRingHttpSignerFactory
     /**
      * Create a new instance of a AWS Ring HTTP signer middleware
      *
+     * @param string $awsRegion AWS region where the instance resides
+     * @param CredentialProvider|null Define how to get the credentials. Defaults to AWS default provider.
      * @return AwsRingHttpSignerInterface Implementation of the AWS Ring HTTP signer middlware
+     * @see CredentialProvider::defaultProvider()
      */
-    public static function create(string $awsRegion): AwsRingHttpSignerInterface
+    public static function create(string $awsRegion, ?CredentialProvider $credentialProvider = null): AwsRingHttpSignerInterface
     {
         return new AwsRingHttpSigner(
             new SignatureV4("es", $awsRegion),

--- a/src/AwsRingHttpSignerFactory.php
+++ b/src/AwsRingHttpSignerFactory.php
@@ -45,15 +45,15 @@ class AwsRingHttpSignerFactory
      * Create a new instance of a AWS Ring HTTP signer middleware
      *
      * @param string $awsRegion AWS region where the instance resides
-     * @param CredentialProvider|null Define how to get the credentials. Defaults to AWS default provider.
+     * @param callable|null Define how to get the credentials. Defaults to AWS default provider.
      * @return AwsRingHttpSignerInterface Implementation of the AWS Ring HTTP signer middlware
      * @see CredentialProvider::defaultProvider()
      */
-    public static function create(string $awsRegion, ?CredentialProvider $credentialProvider = null): AwsRingHttpSignerInterface
+    public static function create(string $awsRegion, ?callable $credentialProvider = null): AwsRingHttpSignerInterface
     {
         return new AwsRingHttpSigner(
             new SignatureV4("es", $awsRegion),
-            CredentialProvider::defaultProvider()
+            $credentialProvider ?? CredentialProvider::defaultProvider()
         );
     }
 }

--- a/tests/AwsRingHttpSignerFactoryTest.php
+++ b/tests/AwsRingHttpSignerFactoryTest.php
@@ -41,6 +41,7 @@ class AwsRingHttpSignerFactoryTest extends TestCase
     {
         $credentials = new Credentials("key", "secret");
         $credentialProvider = CredentialProvider::fromCredentials($credentials);
+        
         $this->assertNotNull(AwsRingHttpSignerFactory::create("eu-central-1", $credentialProvider));
     }
 }

--- a/tests/AwsRingHttpSignerFactoryTest.php
+++ b/tests/AwsRingHttpSignerFactoryTest.php
@@ -27,11 +27,20 @@ namespace Nekman\AwsRingHttpSigner\Test;
 
 use Nekman\AwsRingHttpSigner\AwsRingHttpSignerFactory;
 use PHPUnit\Framework\TestCase;
+use Aws\Credentials\CredentialProvider;
+use Aws\Credentials\Credentials;
 
 class AwsRingHttpSignerFactoryTest extends TestCase
 {
     public function testCreate()
     {
         $this->assertNotNull(AwsRingHttpSignerFactory::create("eu-central-1"));
+    }
+
+    public function testCreate_credential_provider()
+    {
+        $credentials = new Credentials("key", "secret");
+        $credentialProvider = CredentialProvider::fromCredentials($credentials);
+        $this->assertNotNull(AwsRingHttpSignerFactory::create("eu-central-1", $credentialProvider));
     }
 }


### PR DESCRIPTION
Instead of encouraging developers to wire the library themselves, if they need to pass in their own credential provider, add it to the factory instead. The factory is the official API and should support most cases.